### PR TITLE
일기 타입 및 스토어 생성

### DIFF
--- a/src/store/diarySlice.ts
+++ b/src/store/diarySlice.ts
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import Diary from '@src/types/Diary';
+
+interface DiaryState {
+  diary?: Diary;
+}
+
+const initialState: DiaryState = {
+  diary: undefined,
+};
+
+const diaryReducer = createSlice({
+  name: 'diary',
+  initialState,
+  reducers: {
+    //
+  },
+});
+
+export default diaryReducer.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,9 +2,11 @@ import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { useSelector, useDispatch } from 'react-redux';
 
 import uiReducer, { setLoading, setIsDark } from '@src/store/uiSlice';
+import diaryReducer from '@src/store/diarySlice';
 
 const reducers = combineReducers({
   ui: uiReducer,
+  diary: diaryReducer,
 });
 
 const store = configureStore({ reducer: reducers });
@@ -19,3 +21,4 @@ export type RootState = ReturnType<typeof store.getState>;
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 
 export const useUiState = () => useSelector<RootState, RootState['ui']>((state) => state.ui);
+export const useDiaryState = () => useSelector<RootState, RootState['diary']>((state) => state.diary);

--- a/src/types/Diary.ts
+++ b/src/types/Diary.ts
@@ -1,0 +1,26 @@
+type YoutubeInfo = {
+  link: string;
+  title: string;
+  thumbnail: string;
+  playTime: number;
+}
+
+type Emotion = 'ANGRY' | 'HAPPY';
+// TODO: 서버의 값에 맞춰 추가할 예정
+
+type DiaryType =
+  | 'BLUE1'
+  | 'BLUE2'
+  | 'GREEN1'
+  | 'GREEN2';
+
+type Diary = {
+  type: DiaryType;
+  date: Date;
+  title: string;
+  content: string;
+  youtubeInfo: YoutubeInfo;
+  emotion: Emotion;
+}
+
+export default Diary;


### PR DESCRIPTION
## Summary
서버의 Dto를 기반으로 타입을 어느정도 정의하고, 일기 상태를 담을 스토어를 생성합니다.

## Issue
이후 작업은 saga를 연동해서 API를 호출하는 작업을 진행할 예정