### PR TITLE
swiper 가 기획에 맞게 동작하도록 수정한다

### DIFF
--- a/src/pages/preview.tsx
+++ b/src/pages/preview.tsx
@@ -12,6 +12,7 @@ import CardB from '@src/components/CardB';
 
 const PreviewPage = (): ReactElement => {
   const { diary } = useDiaryState();
+
   const dispatch = useAppDispatch();
 
   const [index, setIndex] = useState(0);
@@ -55,9 +56,9 @@ const PreviewPage = (): ReactElement => {
   return (
     <Wrapper>
       <Swiper
+        slidesPerView="auto"
         centeredSlides
-        spaceBetween={30}
-        slidesPerView={2}
+        spaceBetween={15}
         onSlideChange={(e) => setIndex(e.activeIndex)}
       >
         <SwiperSlide>
@@ -83,4 +84,19 @@ const Wrapper = styled.div`
   width: 100vw;
   height: 100vh;
   background: #1c1c1c;
+  
+  .swiper {
+    height: 100%;
+  }
+  .swiper-wrapper {
+    width: 100%;
+    height: 100% !important;
+  }
+  .swiper-slide {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 80% !important;
+    transform: scale(${(window.innerWidth / 280) * 0.8});
+  }
 `;


### PR DESCRIPTION
## Summary
swiper의 기본 css 설정을 따르면 문제가 있어 이를 커스텀했습니다.

## Detail
* 만들어둔 card 두개 모두 고정된 width를 가지고 있어 transform scale을 이용해 width 기준 80%에 맞춤
* overlay 되지 않도록  slidesPerView 옵션을 "auto" 로 설정
* 카드의 height을 100%로 강제하고 가운데로 몰 수 있도록 함

![swiper](https://user-images.githubusercontent.com/16266103/143685433-d8775188-689f-4e6e-b0a9-08651b3f5c55.gif)

## Issue