### PR TITLE
scale을 카드의 높이 기준으로 하도록 변경하고 return 되는 값을 정상화 한다

### DIFF
--- a/src/pages/preview.tsx
+++ b/src/pages/preview.tsx
@@ -41,11 +41,19 @@ const PreviewPage = (): ReactElement => {
 
   useEffect(() => {
     (window as any).selectType = () => {
-      if (index === 0 || index === 2) {
-        return 'A';
+      if (index === 0) {
+        return 'YELLOW1';
       }
 
-      return 'B';
+      if (index === 2) {
+        return 'BLUE1';
+      }
+
+      if (index === 3) {
+        return 'YELLOW2';
+      }
+
+      return 'BLUE2';
     };
   }, [index]);
 

--- a/src/pages/preview.tsx
+++ b/src/pages/preview.tsx
@@ -50,11 +50,11 @@ const PreviewPage = (): ReactElement => {
   }, [index]);
 
   if (!diary) {
-    return <Wrapper />;
+    return <Wrapper calcScale={0} />;
   }
 
   return (
-    <Wrapper>
+    <Wrapper calcScale={(window.innerHeight / 512) * 0.9}>
       <Swiper
         slidesPerView="auto"
         centeredSlides
@@ -80,11 +80,11 @@ const PreviewPage = (): ReactElement => {
 
 export default PreviewPage;
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ calcScale: number }>`
   width: 100vw;
   height: 100vh;
   background: #1c1c1c;
-  
+
   .swiper {
     height: 100%;
   }
@@ -96,7 +96,7 @@ const Wrapper = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    width: 80% !important;
-    transform: scale(${(window.innerWidth / 280) * 0.8});
+    width: ${({ calcScale }) => 280 * calcScale}px !important;
+    transform: scale(${({ calcScale }) => calcScale});
   }
 `;

--- a/src/pages/preview.tsx
+++ b/src/pages/preview.tsx
@@ -45,11 +45,11 @@ const PreviewPage = (): ReactElement => {
         return 'YELLOW1';
       }
 
-      if (index === 2) {
+      if (index === 1) {
         return 'BLUE1';
       }
 
-      if (index === 3) {
+      if (index === 2) {
         return 'YELLOW2';
       }
 
@@ -70,16 +70,16 @@ const PreviewPage = (): ReactElement => {
         onSlideChange={(e) => setIndex(e.activeIndex)}
       >
         <SwiperSlide>
-          <CardA {...diary} />
-        </SwiperSlide>
-        <SwiperSlide>
-          <CardB {...diary} />
-        </SwiperSlide>
-        <SwiperSlide>
           <CardA {...diary} type="YELLOW1" />
         </SwiperSlide>
         <SwiperSlide>
+          <CardA {...diary} type="BLUE1" />
+        </SwiperSlide>
+        <SwiperSlide>
           <CardB {...diary} type="YELLOW2" />
+        </SwiperSlide>
+        <SwiperSlide>
+          <CardB {...diary} type="BLUE2" />
         </SwiperSlide>
       </Swiper>
     </Wrapper>


### PR DESCRIPTION
## Summary
scale을 카드의 높이 기준으로 하도록 변경하고 return 되는 값을 정상화 했습니다.

## Detail
* 안드로이드 웹뷰 기준 카드 위아래가 짤리는 이슈가 있어 scale을 높이 기준으로 하도록 변경
* return 되는 값을 안드쪽에서 요구한 값으로 변경

## Issue